### PR TITLE
Adding Django Hackathon Starter project

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Use these if you want to. Sometimes it is best to study and probably work on you
 
 * <a href='https://github.com/etianen/django-herokuapp' target='_blank'>Django Heroku App</a>
 * <a href='https://github.com/xenith/django-base-template' target='_blank'>Django Base Template</a>
+* <a href='https://github.com/DrkSephy/django-hackathon-starter' target='_blank'> Django Hackathon Starter</a>
 
 ## Meteor.js
 


### PR DESCRIPTION
This pull request adds the following changes:
- Added the [Django Hackathon Starter project](https://github.com/DrkSephy/django-hackathon-starter) - a boilerplate for Django applications containing various Social logins and several API examples. 
